### PR TITLE
Update explainer to reflect that we're no longer considering a separate script-src-v2 directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Explainer for script-src-v2
+# Explainer for expanded hashes in script-src (previously script-src-v2)
 
 This proposal is an early design sketch by the Chrome Secure Web and Network team to describe the problem below and solicit
 feedback on the proposed solution. It has not been approved to ship in Chrome.
@@ -26,16 +26,14 @@ feedback on the proposed solution. It has not been approved to ship in Chrome.
   - [Introduce new url-hashes keyword to cover script-src attributes](#introduce-new-url-hashes-keyword-to-cover-script-src-attributes)
   - [Extend script hashes to cover eval and eval-like functions](#extend-script-hashes-to-cover-eval-and-eval-like-functions)
   - [Add hashes to CSP reporting](#add-hashes-to-csp-reporting)
-  - [Backwards compatibility](#backwards-compatibility)
-    - [Extend script-src with new features, implemented in a way that old browsers can still see a more lax policy](#extend-script-src-with-new-features-implemented-in-a-way-that-old-browsers-can-still-see-a-more-lax-policy)
-    - [Implement the new features as a completely new directive](#implement-the-new-features-as-a-completely-new-directive)
+  - [Extend script-src with new features, implemented in a way that old browsers can still see a more lax policy for backwards compatibility](#extend-script-src-with-new-features-implemented-in-a-way-that-old-browsers-can-still-see-a-more-lax-policy-for-backwards-compatibility)
   - [**Deployment use case examples**](#deployment-use-case-examples)
   - [Single-page applications](#single-page-applications)
   - [Server-side applications](#server-side-applications)
 - [**Considered alternatives**](#considered-alternatives)
   - [Allowlist external scripts directly by URL, instead of URL hash](#allowlist-external-scripts-directly-by-url-instead-of-url-hash)
   - [Overload the existing unsafe-hashes keyword](#overload-the-existing-unsafe-hashes-keyword)
-  - [Support only absolute URL hashes](#support-only-absolute-url-hashes)
+  - [Implement the new features as part of a completely new directive (script-src-v2)](#implement-the-new-features-as-part-of-a-completely-new-directive-script-src-v2)
   - [report-hash keyword](#report-hash-keyword)
 - [**Stakeholder Feedback / Opposition**](#stakeholder-feedback--opposition)
 - [**References & acknowledgements**](#references--acknowledgements)
@@ -44,11 +42,7 @@ feedback on the proposed solution. It has not been approved to ship in Chrome.
 
 ## Introduction
 
-We're proposing new CSP features to help websites protect themselves against DOM XSS. Developers will be able to allowlist scripts that are allowed to execute through the existing hashes mechanism, that will now extend to cover [script-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src) URLs and [eval](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval) (and other eval-like functions). This facilitates an easier to deploy, robust CSP policy that mitigates XSS by blocking unallowed inline and eval scripts. This new features will be implemented in a backwards compatible way, so sites can set a policy that provides better security in browsers that support them without causing breakage in browsers that do not.
-
-To be secure, a policy needs to permit legitimate scripts to execute, while blocking any scripts that the application doesn't expect. In practice, this means avoiding host-based allowlists and having a strict CSP allowing the execution of scripts by using nonces or hashes.
-
-To be easy-to-deploy, a policy should ideally not require developers to make any changes to their application other than adding CSP (usually via an HTTP header or &lt;meta> tag).
+We're proposing new CSP features to help websites protect themselves against DOM XSS. The existing hashes mechanism will be extended to cover [script-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src) URLs and scripts loaded via [eval](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval) (and other eval-like functions). This facilitates an easier to deploy, robust CSP policy that mitigates XSS by blocking unallowed inline and eval scripts. This new features will be implemented in a backwards compatible way, so sites can set a policy that provides better security in browsers that support them without causing breakage in browsers that do not.
 
 
 ## **Goals**
@@ -58,6 +52,7 @@ To be easy-to-deploy, a policy should ideally not require developers to make any
 *   Allow sites to protect themselves from XSS attacks, even if they rely on scripts loaded via eval, or scripts loaded via script-src that change often (i.e. cases where SRI is impractical).
 *   Provide a safe alternative for sites that currently use <code>[unsafe-eval](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_eval_expressions)</code>.
 *   Implement this in a backwards compatible way, so websites can use it without causing breakage for users of browsers that don’t yet support the feature.
+*   Make the new features as easy to deploy as possible. Sites should be able to use the new features with no changes required other than to the CSP policy.
 
 
 ## <strong>Non-goals</strong>
@@ -68,10 +63,6 @@ To be easy-to-deploy, a policy should ideally not require developers to make any
 
 
 ## **Use cases**
-
-XSS is arguably the most dangerous vulnerability class affecting web services for the past 15 years. Content Security Policy was created as a defense-in-depth mechanism to ensure that even when a document suffers from HTML injection, and thus contains arbitrary markup controlled by an attacker, the application will be protected from the execution of untrusted scripts.
-
-The core challenge for CSP is to distinguish between legitimate scripts (intended by the author of the page to execute and usually necessary for an application to function properly) and malicious scripts (potentially injected by an attacker via an HTML injection bug, for example, if a developer has neglected to appropriately escape attacker-controlled data when embedding it in their HTML).
 
 
 ### Allowlisting specific URLs for use with script-src
@@ -110,7 +101,7 @@ Content-Security-Policy: script-src 'url-sha256-SHA256("script.js")';
 
 ### Extend script hashes to cover eval and eval-like functions
 
-Similarly, scripts run within eval() currently can only be allowed via unsafe-eval, which allows any script, with no mechanism to allowlist only specific ones. This proposes that script hashes should cover scripts loaded via eval (Function, or string literals in setTimeout, setInterval, and setImmediate), in addition to inline scripts, e.g. given a CSP of `script-src 'eval-sha256-SHA256(foo)';` permitting `eval(foo);`
+Scripts run within eval() currently can only be allowed via unsafe-eval, which allows any script, with no mechanism to allowlist only specific ones. This proposes that script hashes should cover scripts loaded via eval (Function, or string literals in setTimeout, setInterval, and setImmediate), in addition to inline scripts, e.g. given a CSP of `script-src 'eval-sha256-SHA256(foo)';` permitting `eval(foo);`
 
 
 Prefixes in hashes are necessary to distinguish these from existing hashes supported in script-src. This is useful to prevent scripts from also being unintentionally allowlisted as inline scripts, and is also required to implement backwards compatibility (so browsers that understand the new features can detect when they are being used).
@@ -123,11 +114,7 @@ In order to facilitate easier adoption, script hashes should also be added to CS
 This necessitates adding two fields: the hash of the content of a script (for inline/eval scripts), and the hash of the URL (initial URL, without following redirects) of the script (for script src elements).
 
 
-### Backwards compatibility
-One of the goals is for the new features to be deployable on sites without breaking on older browsers. There are two ways to achieve this:
-
-
-#### Extend script-src with new features, implemented in a way that old browsers can still see a more lax policy
+### Extend script-src with new features, implemented in a way that old browsers can still see a more lax policy for backwards compatibility
 This would extend the existing script-src directive with 2 new keywords, `eval-<hashalgorithm>-<hash>` and `url-<hashalgorithm>-<hash>`. For eval, backwards compatibility would be achieved by browsers that support the new features ignore `unsafe-eval` if one or more eval hashes are present (which matches the existing behavior for `unsafe-inline`, which is [ignored if script hashes are present](https://www.w3.org/TR/CSP3/#allow-all-inline)). This would allow a site that needs to use eval to set both unsafe-eval and the script hashes. Browsers that don't support the new feature would still work due to the presence of unsafe-eval (and ignore the hashes since they don't understand that keyword), while browsers that support hashes would ignore `unsafe-eval`. In practice this would look like:
 
 
@@ -147,12 +134,6 @@ For URL hashes, a similar approach can be followed. Browsers that support the ne
   -If implemented this way, strict-dynamic behavior could also be limited to scripts loaded via a hashed URL.
 - Having the presence of URL hashes imply strict-dynamic, and providing an opt-out keyword, e.g. `no-strict-dynamic-hashes`.
 
-#### Implement the new features as a completely new directive
-The new features can be implemented as part of a separate directive (e.g. `script-src-v2`) that completely replaces `script-src` if it's set. This has the advantage of making the policy easier to read since it's immediately obvious what applies in browsers that are compatible with the new features, and what is the fallback for browsers that are not. On the other hand, the main drawback to this approach is that moves the complexity to the [fallback algorithm](https://www.w3.org/TR/CSP3/#directive-fallback-list).
-
-Both `script-src-elem` and `script-src-attr` fallback directly to `script-src` so they can be handled by either introducing a replacement that supports the new features and replaces the other one if set(e.g. `script-src-elem-v2`), or by completely ignoring them if `script-src-v2` is set.
-
-`worker-src`, `child-src`, and `default-src` interact with `script-src`, but also with other directives, so adding a "v2" version of them leads to an overly complicated algorithm. Alternatively we can add support for url hashes directly on these directives, but that means the only way to have a backup policy for browsers that don't support them, is to not rely on the fallback algorithm and use `script-src` directly. Finally, we can also choose to not support the new features in these, but this leads to a scenario where sites that want to use URL hashes for workers have to *not* set `worker-src` and are forced to rely on the fallback to `script-src`
 
 ### **Deployment use case examples**
 
@@ -207,6 +188,16 @@ While it would be possible to introduce a new URL-based directive with different
 For simplicity, we could reuse `unsafe-hashes` to have hashes apply to eval and script URLs, however in the eval case, this would mean that scripts would be implicitly allowlisted for event handlers, which is not intended. For this reason we decided not to require unsafe-hashes for eval. This design implicitly allows scripts allowlisted for eval via hashes to also be used in an inline block. This seems fine, but if it’s determined that we do need a keyword to split allowlisting scripts for eval from allowlisting them for inline use, we can add a separate eval-hashes keyword.
 
 We propose using the new url-hashes keyword instead of reusing unsafe-hashes to avoid confusion from using the same directive to allow two different uses (and since allowlisting urls is not, in fact, “unsafe”).
+
+
+### Implement the new features as part of a completely new directive (script-src-v2)
+The new features could also be implemented as part of a separate directive (e.g. `script-src-v2`) that completely replaces `script-src` if it's set. This has the advantage of making the policy easier to read since it's immediately obvious what applies in browsers that are compatible with the new features, and what is the fallback for browsers that are not. The main drawback to this approach is that moves the complexity to the [fallback algorithm](https://www.w3.org/TR/CSP3/#directive-fallback-list).
+
+Both `script-src-elem` and `script-src-attr` fallback directly to `script-src` so they can be handled by either introducing a replacement that supports the new features and replaces the other one if set(e.g. `script-src-elem-v2`), or by completely ignoring them if `script-src-v2` is set.
+
+`worker-src`, `child-src`, and `default-src` interact with `script-src`, but also with other directives, so adding a "v2" version of them leads to an overly complicated algorithm. Alternatively we can add support for url hashes directly on these directives, but that means the only way to have a backup policy for browsers that don't support them, is to not rely on the fallback algorithm and use `script-src` directly. Finally, we can also choose to not support the new features in these, but this leads to a scenario where sites that want to use URL hashes for workers have to *not* set `worker-src` and are forced to rely on the fallback to `script-src`
+
+Due to this added complexity, we decided to implement the new features in the existing `script-src` directive as described in the previous section isntead.
 
 
 ### report-hash keyword


### PR DESCRIPTION
This also removes/reorganizes some introduction text that seemed a bit redundant.